### PR TITLE
mrc-6590 Check published packets exist before setting scoped permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,22 +18,22 @@ services:
       - api
     volumes:
       - orderly_volume:/orderly
-  orderly-web-packit:
-    image: mrcide/montagu-packit:main
+  packit:
+    image: ghcr.io/mrc-ide/montagu-packit:main
     networks:
       - proxy
-  orderly-web-packit-api:
-    image: mrcide/packit-api:main
+  packit-api:
+    image: ghcr.io/mrc-ide/packit-api:main
     networks:
       - proxy
     depends_on:
-      orderly-web-packit-db:
+      packit-db:
         condition: service_healthy
       outpack_server:
         condition: service_started
     environment:
       - PACKIT_OUTPACK_SERVER_URL=http://outpack_server:8000
-      - PACKIT_DB_URL=jdbc:postgresql://orderly-web-packit-db:5432/packit?stringtype=unspecified
+      - PACKIT_DB_URL=jdbc:postgresql://packit-db:5432/packit?stringtype=unspecified
       - PACKIT_DB_USER=packituser
       - PACKIT_DB_PASSWORD=changeme
       - PACKIT_JWT_SECRET=changesecretkey
@@ -43,8 +43,8 @@ services:
       - PACKIT_AUTH_ENABLED=true
       - PACKIT_AUTH_GITHUB_ORG=none
       - PACKIT_AUTH_GITHUB_TEAM=none
-  orderly-web-packit-db:
-    image: mrcide/packit-db:main
+  packit-db:
+    image: ghcr.io/mrc-ide/packit-db:main
     networks:
       - proxy
     healthcheck:
@@ -90,8 +90,8 @@ services:
     depends_on:
       - api
       - orderly-web-web
-      - orderly-web-packit
-      - orderly-web-packit-api
+      - packit
+      - packit-api
       - contrib
       - admin
     networks:

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -120,17 +120,17 @@ $here/orderly_web_cli.sh grant funder.user@example.com report:html/reports.read
 $here/orderly_web_cli.sh grant dev.user@example.com */reports.run
 
 # Add two non-admin roles
-$here/orderly_web_cli.sh add-groups funder developer
+$here/orderly_web_cli.sh add-groups Funder Developer
 
 # Give different perms to the roles than those the users have directly
-$here/orderly_web_cli.sh grant developer */reports.review */users.manage */reports.read
+$here/orderly_web_cli.sh grant Developer */reports.review */users.manage */reports.read
 # other has two published and two unpublished versions, interactive has one unpublished, use_resource has one published.
 # So funder role should have three packet read perms
-$here/orderly_web_cli.sh grant funder report:other/reports.read report:interactive/reports.read report:use_resource/reports.read */documents.read
+$here/orderly_web_cli.sh grant Funder report:other/reports.read report:interactive/reports.read report:use_resource/reports.read */documents.read
 
 # Add users to their group roles
-$here/orderly_web_cli.sh add-members developer dev.user@example.com
-$here/orderly_web_cli.sh add-members funder funder.user@example.com
+$here/orderly_web_cli.sh add-members Developer dev.user@example.com
+$here/orderly_web_cli.sh add-members Funder funder.user@example.com
 $here/orderly_web_cli.sh add-members Admin admin.user@example.com
 
 echo "Dependencies are running. Press Ctrl+C to teardown."

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -82,7 +82,7 @@ $here/orderly_web_cli.sh grant test.user@example.com */reports.review
 $here/orderly_web_cli.sh grant test.user@example.com */users.manage
 
 # Add test (admin) user to packit
-PACKIT_DB=montagu-orderly-web-packit-db-1
+PACKIT_DB=montagu-packit-db-1
 docker exec $PACKIT_DB create-preauth-user --username "test.user" --email "test.user@example.com" --displayname "Test User" --role "ADMIN"
 
 # Add some other example users and roles which we can test the migration against

--- a/scripts/science.sh
+++ b/scripts/science.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -ex
+here=$(dirname $0)
+
+echo "MIGRATING ORDERLY WEB PERMISSIONS TO PACKIT ON SCIENCE"
+
+export MIGRATE_MONTAGU_URL=https://science.montagu.dide.ic.ac.uk/api
+export MIGRATE_OW_URL=https://science.montagu.dide.ic.ac.uk/reports
+export MIGRATE_PACKIT_API_URL=https://science.montagu.dide.ic.ac.uk/packit/api
+export MIGRATE_USER=
+export MIGRATE_PASSWORD=
+
+hatch env run migrate-perms

--- a/src/migrate_packit_perms_from_orderly_web/migrate.py
+++ b/src/migrate_packit_perms_from_orderly_web/migrate.py
@@ -33,6 +33,10 @@ class Migrate:
 
         # Get all published report versions
         self.published_report_versions = self.orderly_web.get_published_report_versions()
+        nonexistent_packets = self.packit.check_packets_exist(self.published_report_versions)
+        if (len(nonexistent_packets)):
+            print(f"WARNING: The following {len(nonexistent_packets)} expected packets do not exist, and will not have related permissions created. "
+            + f"There may have been an issue with migrating packets from OrderlyWeb.\n {nonexistent_packets}")
 
         map_perms = MapPermissions(self.published_report_versions)
 

--- a/src/migrate_packit_perms_from_orderly_web/packit_permissions.py
+++ b/src/migrate_packit_perms_from_orderly_web/packit_permissions.py
@@ -47,8 +47,6 @@ class PackitPermissions:
         headers["Content-Type"] = "application/json"
         response = requests.put(url, data = json.dumps(data), headers = headers, verify = self.verify)
         if response.status_code != 200:
-            print("error response")
-            print(response.text)
             raise Exception(f"Unexpected status code {response.status_code} for PUT {url}")
 
     def delete(self, relative_url):
@@ -92,7 +90,7 @@ class PackitPermissions:
 
     # This is used to check if packets referenced in scoped permissions (including those relevant to published report
     # permissions actually exist in packit). If not, this may indicate a problem with report migration. If any do not
-    # exist, remove from list of packets to set permissions for, and return separately
+    # exist, remove from list of packets to set permissions for, and return these separately
     def check_packets_exist(self, packets_by_group):
         nonexistent = []
         for packet_group, ids in packets_by_group.items():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,7 @@ def test_migrate():
     # reports.review => packet.read (global), packet.manage (global), outpack.read
     # users.manage => user.manage
     # reports.read => no effect as reports-review already grants global read
-    developer_perms = sut.packit_roles_to_create["developer"]
+    developer_perms = sut.packit_roles_to_create["Developer"]
     assert len(developer_perms) == 4
     assert permission_matches(developer_perms[0], "packet.read")
     assert permission_matches(developer_perms[1], "packet.manage")
@@ -93,7 +93,7 @@ def test_migrate():
     # Funder role:
     # packet.read: "other" published version packets * 2
     # packet.read: "use_resource" published version * 1
-    funder_perms = sut.packit_roles_to_create["funder"]
+    funder_perms = sut.packit_roles_to_create["Funder"]
     assert len(funder_perms) == 3
     assert permission_matches(funder_perms[0], "packet.read", published_report_versions["other"][0])
     assert permission_matches(funder_perms[1], "packet.read", published_report_versions["other"][1])
@@ -102,7 +102,7 @@ def test_migrate():
     assert len(sut.packit_users_to_create.keys()) == 3
 
     dev_user = sut.packit_users_to_create["dev.user"]
-    assert dev_user["roles"] == ["developer"]
+    assert dev_user["roles"] == ["Developer"]
     # Dev user direct perms:
     # report.run => packet.run, outpack.read
     dev_user_perms = dev_user["direct_permissions"]
@@ -111,7 +111,7 @@ def test_migrate():
     assert permission_matches(dev_user_perms[1], "outpack.read")
 
     funder_user = sut.packit_users_to_create["funder.user"]
-    assert funder_user["roles"] == ["funder"]
+    assert funder_user["roles"] == ["Funder"]
     # Funder user direct perms
     # packet.read: html * 1
     # packet.read: minimal * 1
@@ -130,17 +130,17 @@ def test_migrate():
     users = sut.packit.get_users()
     assert_packit_users(users, ["admin.user", "dev.user", "funder.user", "test.user" ])
     assert_packit_user_matches(users[0], "admin.user", "admin.user@example.com", "Admin User", ["ADMIN"])
-    assert_packit_user_matches(users[1], "dev.user", "dev.user@example.com", "Dev User", ["developer"])
-    assert_packit_user_matches(users[2], "funder.user", "funder.user@example.com", "Funder User", ["funder"])
+    assert_packit_user_matches(users[1], "dev.user", "dev.user@example.com", "Dev User", ["Developer"])
+    assert_packit_user_matches(users[2], "funder.user", "funder.user@example.com", "Funder User", ["Funder"])
 
     # Role permissions, including user roles
     roles = sut.packit.get_roles()
-    assert_packit_roles(roles, ["ADMIN", "admin.user", "developer", "funder", "dev.user", "funder.user", "test.user"])
+    assert_packit_roles(roles, ["ADMIN", "admin.user", "Developer", "Funder", "dev.user", "funder.user", "test.user"])
 
-    created_developer_role = role_from_list(roles, "developer")
+    created_developer_role = role_from_list(roles, "Developer")
     assert_created_permissions_match_update_permissions(created_developer_role["rolePermissions"], developer_perms)
 
-    created_funder_role = role_from_list(roles, "funder")
+    created_funder_role = role_from_list(roles, "Funder")
     assert_created_permissions_match_update_permissions(created_funder_role["rolePermissions"], funder_perms)
 
     created_admin_user_role = role_from_list(roles, "admin.user")


### PR DESCRIPTION
I think the reason permissions could not be applied in Science was because some published report versions did not have corresponding packets. 

I've added a check for these expected packets - if any do not exist we remove them from the list and will not attempt to set scoped permissions for them (for publish equivalent only - we could still have the same problem for deliberately set scoped permissions, but this seems much less likely). 

4 such packets were found on science:
```
 [{'packet_group': 'diagnostics-burden-report', 'id': '20250626-150254-745f5c2e'}, 
{'packet_group': 'diagnostics-burden-report', 'id': '20250626-151437-90a73de9'}, 
{'packet_group': 'diagnostics-impact-report', 'id': '20250626-152719-0347cb9f'}, 
{'packet_group': 'malaria-vaccine-impact-on-all-cause-mortality', 'id': '20250625-163626-6c314b33'}]
```
The migrate prepare step prints details of these missing packets if any are found. 

There are also changes in this branch related to container name changes etc. 

I've run the prepare step against Science, but haven't actually attempted migrate yet - you might want to look over the code before I do so!